### PR TITLE
Transform ellipsoid input to uppercase

### DIFF
--- a/coorblimey/geocentrics.py
+++ b/coorblimey/geocentrics.py
@@ -13,7 +13,7 @@ class Geocentrics():
         self.x = x
         self.y = y
         self.z = z
-        self.ellipsoid = ellipsoid
+        self.ellipsoid = ellipsoid.upper()
         if self.ellipsoid == 'GRS80':
             self.a = 6378137.0
             self.b = 6356752.314140


### PR DESCRIPTION
GRS80 and WGS84 are the _strictly_ correct ellipsoid names, but allowing lowercase (or even mixed-case) input seems like a user-friendly feature 
